### PR TITLE
Improve sentiment feed parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+🇹🇷 Türkiye Ekonomisi Kıyamet Saati (Doom Watch) ⏳
+Bu proje, Türkiye ekonomisindeki olası riskleri çeşitli göstergeler ve halkın genel duyarlılığı üzerinden değerlendiren, basit ama etkili bir risk göstergesi uygulamasıdır. Anlık piyasa verilerini ve haber akışlarını kullanarak güncel ekonomik risk seviyesini görselleştirir.
+
+⚠️ ÖNEMLİ NOT: Bu proje eğitim ve simülasyon amaçlıdır. Finansal kararlar alırken LÜTFEN bu uygulamadaki verilere doğrudan güvenmeyin. Piyasa koşulları sürekli değişir ve finansal kararlar uzman tavsiyesi gerektirir.
+
+🚀 Proje Hakkında
+"Türkiye Ekonomisi Kıyamet Saati", belirli ekonomik göstergeleri (faiz, enflasyon, işsizlik, döviz volatilitesi vb.) ve özellikle gerçek zamanlı haber akışlarından elde edilen kamu duyarlılığını analiz ederek bir risk skoru hesaplar. Hesaplanan skor, 0 (düşük risk) ile 1 (yüksek risk) arasında bir değer alır ve zaman içindeki seyrini gösteren basit bir grafik ile sunulur.
+
+Temel Özellikler:
+
+📰 RSS Destekli Duygu Analizi: Belirli RSS feed'lerinden (Investing.com, BBC Türkçe, Dünya Bankası) ekonomi haberlerini çeker ve içeriğindeki duygu tonunu (pozitif/negatif) analiz ederek genel piyasa duyarlılığını ölçer.
+📈 Risk Skoru Hesaplama: Çeşitli ekonomik parametreleri ağırlıklandırarak birleşik bir risk skoru oluşturur.
+📊 Görselleştirme: Risk seviyesini kolay anlaşılır bir çizgi grafik üzerinde gösterir ve risk bölgelerini (düşük, orta, yüksek) belirtir.
+🚨 Anlık Uyarılar: Yüksek risk durumlarında (veya BIST'te ani düşüşlerde) Telegram üzerinden bildirim gönderebilir (ayarları yapılması gerekir).
+⚙️ Kolay Kullanım Arayüzü: Streamlit ile oluşturulmuş basit web arayüzü sayesinde herkesin kolayca kullanabileceği bir yapıya sahiptir.
+🛠️ Kurulum
+Uygulamayı kendi bilgisayarında çalıştırmak için aşağıdaki adımları sırasıyla takip etmelisin:
+
+Adım 1: Proje Dosyalarını Edinin
+Bu projenin tüm Python dosyalarını (örn: doom_watch.py, sentiment.py, streamlit_app.py vb.) tek bir klasöre indirin veya kopyalayın.
+Bu klasöre örneğin EkonomiKiyametSaati gibi anlamlı bir isim verin.
+Bu klasörün bilgisayarınızdaki yolunu aklınızda tutun (örn: C:\Kullanicilar\KullaniciAdiniz\Belgeler\EkonomiKiyametSaati).
+Adım 2: Python Ortamını Hazırlayın
+Uygulama Python ile yazılmıştır, bu yüzden bilgisayarınızda Python'ın kurulu olması gerekir.
+
+Python Kurulu mu Kontrol Edin:
+
+Windows: Başlat menüsünden "Komut İstemi"ni (Command Prompt) veya "PowerShell"i açın.
+Mac/Linux: "Terminal" uygulamasını açın.
+Açılan pencereye python --version yazın ve Enter'a basın.
+Eğer Python 3.x.x gibi bir sürüm numarası görüyorsanız, Python kurulu demektir.
+Eğer hata veriyorsa, Python'ın resmi web sitesinden (python.org) en son sürümü indirip kurmanız gerekir. Kurulum sırasında "Add Python to PATH" (veya benzeri bir ifade) kutucuğunu işaretlemeyi KESİNLİKLE unutmayın! Bu adım çok önemlidir.
+pip Aracını Güncelleyin:
+
+pip, Python kütüphanelerini yüklememizi sağlayan araçtır. Komut İstemi/Terminal'de aşağıdaki komutu çalıştırın:
+```bash
+python -m pip install --upgrade pip
+```
+Adım 3: Gerekli Kütüphaneleri Yükleyin
+Şimdi uygulamanın çalışması için ihtiyaç duyduğu ek kütüphaneleri yükleyeceğiz.
+
+Proje Klasörüne Gidin: Komut İstemi/Terminal'de, Adım 1'de oluşturduğunuz EkonomiKiyametSaati klasörüne gitmeniz gerekiyor. Bunun için cd (change directory) komutunu kullanın:
+```bash
+cd C:\Kullanicilar\KullaniciAdiniz\Belgeler\EkonomiKiyametSaati
+# Kendi klasör yolunuzu yukarıdaki örnekle değiştirin!
+```
+Kütüphaneleri Yükleyin: Klasörün içindeyken, aşağıdaki komutu tek bir satırda kopyalayıp Komut İstemi/Terminal'e yapıştırın ve Enter'a basın:
+```bash
+pip install streamlit pandas numpy matplotlib requests feedparser transformers torch
+```
+Bu komut, uygulamanın tüm bağımlılıklarını otomatik olarak indirip kuracaktır. İşlem, internet hızınıza bağlı olarak birkaç dakika sürebilir.
+🚀 Uygulamayı Çalıştırın!
+Tebrikler! Artık her şey hazır. Uygulamayı başlatmak için son bir adım kaldı:
+
+Uygulama Başlatma Komutu: Hala EkonomiKiyametSaati klasörünüzün içinde olmanız gerekiyor. Komut İstemi/Terminal'de aşağıdaki komutu yazın ve Enter'a basın:
+```bash
+streamlit run streamlit_app.py
+```
+Tarayıcınız Açılacak: Komutu çalıştırdığınızda, varsayılan web tarayıcınız (Chrome, Firefox vb.) otomatik olarak açılacak ve "Türkiye Ekonomisi Kıyamet Saati" uygulaması karşınıza gelecektir.
+
+💡 Uygulamayı Kullanma
+Uygulama arayüzü açıldığında:
+
+"Tarih Seç": Simülasyon amaçlı bir tarih seçebilirsiniz.
+"Otomotiv Talep Değişimi": Bu alana, 3 aylık otomotiv talebindeki değişimi manuel olarak (örneğin -0.05 veya 0.03 gibi) girebilirsiniz.
+"Veriyi Güncelle ve Risk Skorunu Hesapla" Butonu: Bu butona tıkladığınızda uygulama:
+Belirtilen RSS feed'lerinden güncel ekonomi haberlerini çekecek ve duygu analizini yapacak.
+Diğer ekonomik göstergeleri (şimdilik bazıları simüle edilmiş veya manuel olarak girilmiş) birleştirecek.
+Tüm bu verilere dayanarak güncel risk skorunu hesaplayıp ekranda gösterecek.
+Risk skorunun zaman içindeki değişimini gösteren bir grafiği sunacak.
+Borsa İstanbul'da (BIST-100) ani bir düşüş tespit ederse size uyarı verecektir.
+🤝 Katkıda Bulunma
+Bu proje açık kaynaklıdır ve GPLv3 Lisansı ile lisanslanmıştır. Kodda gördüğünüz eksiklikleri gidermek, yeni özellikler eklemek veya iyileştirmeler yapmak isterseniz, katkılarınızı memnuniyetle karşılarız!
+
+Hata raporları için Issues bölümünü kullanın.
+Kod katkıları için Pull Request (PR) gönderebilirsiniz.
+Umarız bu uygulama, Türkiye ekonomisindeki risk algısını anlamanıza yardımcı olur. İyi kullanımlar!

--- a/alerts.py
+++ b/alerts.py
@@ -1,0 +1,13 @@
+import requests
+
+
+def send_telegram(msg: str) -> None:
+    """Send a Telegram message using bot credentials."""
+    bot_token = "YOUR_BOT_TOKEN"
+    chat_id = "YOUR_CHAT_ID"
+    url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+    try:
+        requests.get(url, params={"text": msg, "chat_id": chat_id}, timeout=10)
+    except Exception:
+        pass
+

--- a/anomaly.py
+++ b/anomaly.py
@@ -1,0 +1,29 @@
+"""Anomaly detection utilities using Prophet."""
+
+from typing import Dict, List
+
+import logging
+import numpy as np
+import pandas as pd
+from prophet import Prophet
+
+
+def detect_anomaly(data_window: List[Dict[str, float]]) -> bool:
+    """Return True if the latest aggregated value deviates above forecast."""
+    if len(data_window) < 3:
+        return False
+
+    # Average values into a single series
+    df = pd.DataFrame(data_window)
+    df["y"] = df.mean(axis=1)
+    df["ds"] = pd.date_range(end=pd.Timestamp.today(), periods=len(df))
+
+    try:
+        model = Prophet()
+        model.fit(df[["ds", "y"]])
+        future = model.make_future_dataframe(periods=1)
+        forecast = model.predict(future)
+        return forecast["yhat"].iloc[-1] > forecast["yhat_upper"].iloc[-1]
+    except Exception as exc:
+        logging.warning("prophet anomaly detection failed: %s", exc)
+        return False

--- a/doom_watch.py
+++ b/doom_watch.py
@@ -1,0 +1,181 @@
+# Example risk indicator using simulated data.
+# Not intended for real trading or investment decisions.
+
+import datetime
+import logging
+import math
+import random
+import requests
+from typing import Dict, List, Tuple, Optional
+
+from alerts import send_telegram
+from market_watch import check_google_trends, check_bist_crash
+from sentiment import get_public_sentiment, fetch_rss_texts
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+
+from politika_scenarios import scenario_adjustment
+
+# Normalization parameters for economic indicators
+NORMALIZATION = {
+    "faiz_orani": {"min": 0.0, "max": 1.0, "mean": 0.5, "std": 0.1},
+    "doviz_kur_volatilite": {"min": 0.0, "max": 0.1, "mean": 0.03, "std": 0.02},
+    "enflasyon_farki": {"min": 0.0, "max": 0.3, "mean": 0.1, "std": 0.05},
+    "issizlik_orani": {"min": 0.0, "max": 0.2, "mean": 0.1, "std": 0.03},
+    "otomotiv_talep_degisimi": {"min": -0.2, "max": 0.1, "mean": -0.05, "std": 0.07},
+    "global_ticaret_gerilimi_index": {"min": 0.0, "max": 1.0, "mean": 0.5, "std": 0.2},
+    "politik_belirsizlik_skoru": {"min": 0.0, "max": 1.0, "mean": 0.7, "std": 0.15},
+    "guven_endeksi_degisimi": {"min": -0.05, "max": 0.05, "mean": -0.01, "std": 0.02},
+    "public_sentiment": {"min": -1.0, "max": 1.0, "mean": 0.0, "std": 0.5},
+}
+
+SCALER = "minmax"  # or 'zscore'
+
+_CACHED_DATA: Optional[Dict[str, float]] = None
+HISTORY: Dict[str, List[float]] = {k: [] for k in NORMALIZATION}
+
+
+
+def normalize_value(name: str, value: float) -> float:
+    """Normalize a value using the configured scaler and rolling history."""
+    params = NORMALIZATION[name]
+    hist = HISTORY.get(name, [])
+    if hist:
+        mean = sum(hist) / len(hist)
+        std = (sum((x - mean) ** 2 for x in hist) / len(hist)) ** 0.5
+        params = {**params, "min": min(hist), "max": max(hist), "mean": mean, "std": std}
+    if SCALER == "zscore":
+        z = (value - params["mean"]) / params["std"] if params["std"] else 0.0
+        return 1 / (1 + math.exp(-z))
+    norm = (value - params["min"]) / (params["max"] - params["min"])
+    return max(0.0, min(norm, 1.0))
+
+
+
+
+def get_live_data() -> Dict[str, float]:
+    """Fetch live economic data (simulated for now)."""
+    global _CACHED_DATA
+    data: Dict[str, float] = {}
+
+    data["public_sentiment"] = get_public_sentiment()
+
+    data["faiz_orani"] = (_CACHED_DATA or {}).get("faiz_orani", random.uniform(0.40, 0.60))
+
+    cpi_sim = (_CACHED_DATA or {}).get("cpi", random.uniform(0.40, 0.70) * 100)
+    ppi_sim = cpi_sim * random.uniform(0.8, 1.2)
+    data["enflasyon_farki"] = abs((cpi_sim - ppi_sim) / 100.0)
+
+    data["issizlik_orani"] = (_CACHED_DATA or {}).get("issizlik_orani", random.uniform(0.08, 0.12))
+
+    data["doviz_kur_volatilite"] = (_CACHED_DATA or {}).get("doviz_kur_volatilite", random.uniform(0.01, 0.05))
+
+    data.setdefault("otomotiv_talep_degisimi", random.uniform(-0.15, 0.05))
+    data.setdefault("global_ticaret_gerilimi_index", random.uniform(0.5, 1.0))
+    data.setdefault("politik_belirsizlik_skoru", random.uniform(0.6, 1.0))
+    data.setdefault("guven_endeksi_degisimi", random.uniform(-0.03, 0.02))
+
+    for key in HISTORY:
+        if key in data:
+            HISTORY[key].append(data[key])
+            HISTORY[key] = HISTORY[key][-12:]
+
+    _CACHED_DATA = data
+    return data
+
+
+def calculate_risk_score(data: Dict[str, float]) -> Tuple[float, List[str]]:
+    """Calculate a risk score from live data."""
+    weights = {
+        "faiz_orani": 0.15,
+        "doviz_kur_volatilite": 0.20,
+        "enflasyon_farki": 0.20,
+        "issizlik_orani": 0.10,
+        "otomotiv_talep_degisimi": 0.08,
+        "global_ticaret_gerilimi_index": 0.05,
+        "politik_belirsizlik_skoru": 0.07,
+        "guven_endeksi_degisimi": 0.05,
+        "public_sentiment": 0.10,
+    }
+
+    risk_contributions = {
+        "faiz_orani": normalize_value("faiz_orani", data["faiz_orani"]),
+        "doviz_kur_volatilite": normalize_value("doviz_kur_volatilite", data["doviz_kur_volatilite"]),
+        "enflasyon_farki": normalize_value("enflasyon_farki", data["enflasyon_farki"]),
+        "issizlik_orani": normalize_value("issizlik_orani", data["issizlik_orani"]),
+        "otomotiv_talep_degisimi": 1 - normalize_value("otomotiv_talep_degisimi", data["otomotiv_talep_degisimi"]),
+        "global_ticaret_gerilimi_index": normalize_value("global_ticaret_gerilimi_index", data["global_ticaret_gerilimi_index"]),
+        "politik_belirsizlik_skoru": normalize_value("politik_belirsizlik_skoru", data["politik_belirsizlik_skoru"]),
+        "guven_endeksi_degisimi": 1 - normalize_value("guven_endeksi_degisimi", data["guven_endeksi_degisimi"]),
+        "public_sentiment": 1 - ((data.get("public_sentiment", 0) + 1) / 2),
+    }
+
+    base_score = sum(risk_contributions[f] * weights[f] for f in weights)
+    if check_google_trends(["dolar ne olacak", "ekonomi kötü mü"]):
+        base_score += 0.05
+    adjustment, triggered = scenario_adjustment(data)
+    total = min(1.0, max(0.0, base_score + adjustment))
+    return total, triggered
+
+
+def plot_risk_indicator(current_risk_score: float) -> None:
+    """Visualize the risk level over time as a line chart."""
+    today = datetime.date.today()
+    dates = [today - datetime.timedelta(days=i * 30) for i in range(3, 0, -1)] + [
+        today + datetime.timedelta(days=i * 30) for i in range(7)
+    ]
+    risk_values = [
+        max(0.6, current_risk_score - random.uniform(0.1, 0.2) + random.uniform(-0.02, 0.02))
+        for _ in range(3)
+    ] + [current_risk_score] + [
+        min(0.99, current_risk_score + random.uniform(-0.01, 0.03)) for _ in range(6)
+    ]
+
+    plt.figure(figsize=(12, 6))
+    plt.plot(dates, risk_values[: len(dates)], marker="o", linestyle="-", color="blue", alpha=0.7)
+    plt.plot(today, current_risk_score, marker="X", markersize=12, color="red", label=f"Bugünkü Risk: {current_risk_score:.2f}")
+    plt.axhspan(0, 0.4, color="green", alpha=0.1, label="Düşük Risk")
+    plt.axhspan(0.4, 0.7, color="orange", alpha=0.1, label="Orta Risk")
+    plt.axhspan(0.7, 1.0, color="red", alpha=0.1, label="Yüksek Risk")
+    plt.title("Türkiye Ekonomisi Kıyamet Saati - Risk Göstergesi")
+    plt.xlabel("Tarih")
+    plt.ylabel("Risk Skoru (0-1)")
+    plt.grid(True, linestyle="--", alpha=0.7)
+    plt.gca().xaxis.set_major_formatter(mdates.DateFormatter("%d %b %Y"))
+    plt.gca().xaxis.set_major_locator(mdates.MonthLocator(interval=1))
+    plt.gcf().autofmt_xdate()
+    plt.ylim(0, 1.0)
+    plt.legend()
+    plt.tight_layout()
+    # plt.show()  # Streamlit uses st.pyplot() instead
+
+
+def main() -> None:
+    """Run a single update of the risk indicator."""
+    print("Türkiye Ekonomisi Kıyamet Saatini Başlatıyorum Kanka!")
+    current_data = get_live_data()
+    print("\nGüncel Veri Seti:")
+    for key, value in current_data.items():
+        print(f"  {key}: {value:.2f}")
+
+    risk_score, scenarios = calculate_risk_score(current_data)
+    print(f"\nHesaplanan Güncel Risk Skoru: {risk_score:.2f}")
+    if scenarios:
+        print("Tetiklenen Senaryolar:", ", ".join(scenarios))
+
+    plot_risk_indicator(risk_score)
+
+    print("\nKıyamet Saati göstergesi güncellendi.")
+    if risk_score > 0.75:
+        print("UYARI: Risk Seviyesi Yüksek! Piyasalar alarm veriyor.")
+        send_telegram("\u26a0\ufe0f Yüksek ekonomik risk tespit edildi!")
+    elif risk_score > 0.55:
+        print("DİKKAT: Risk Seviyesi Orta! Gelişmeler takip edilmeli.")
+    else:
+        print("NORMAL: Risk Seviyesi Düşük. Piyasalar sakin seyrediyor.")
+
+    check_bist_crash()
+
+
+if __name__ == "__main__":
+    main()

--- a/doom_watch_modules.py
+++ b/doom_watch_modules.py
@@ -1,0 +1,69 @@
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+from sklearn.tree import DecisionTreeClassifier
+from transformers import pipeline
+
+
+def detect_anomalies(
+    data: Dict[str, float],
+    normal_params: Dict[str, Dict[str, float]],
+    method: str = "zscore",
+) -> Dict[str, bool]:
+    """Return anomaly flags for data using z-score or IQR."""
+    anomalies: Dict[str, bool] = {}
+    for key, value in data.items():
+        params = normal_params.get(key, {})
+        mean = params.get("mean", 0.0)
+        std = params.get("std", 1.0)
+        if method == "zscore":
+            z = abs((value - mean) / std) if std else 0.0
+            anomalies[key] = z > 2
+        else:
+            q1 = params.get("q1", 0.0)
+            q3 = params.get("q3", 0.0)
+            iqr = q3 - q1
+            anomalies[key] = value < (q1 - 1.5 * iqr) or value > (q3 + 1.5 * iqr)
+    return anomalies
+
+
+def calculate_momentum(gecmis_values: Dict[str, List[float]]) -> Dict[str, float]:
+    """Compute simple momentum metrics from historical values."""
+    momentums: Dict[str, float] = {}
+    for key, values in gecmis_values.items():
+        if len(values) >= 2:
+            momentum = values[-1] - values[-2]
+        else:
+            momentum = 0.0
+        momentums[key] = momentum
+    return momentums
+
+
+def analyze_sentiment(texts: List[str]) -> float:
+    """Analyze sentiment of provided texts using a Turkish BERT model."""
+    if not texts:
+        return 0.0
+
+    sentiment_pipeline = pipeline(
+        "sentiment-analysis",
+        model="savasy/bert-base-turkish-sentiment-cased",
+        tokenizer="savasy/bert-base-turkish-sentiment-cased",
+    )
+
+    scores = []
+    for text in texts:
+        result = sentiment_pipeline(text)[0]
+        label = result.get("label", "")
+        score = result.get("score", 0.0)
+        scores.append(score if "POS" in label.upper() else -score)
+
+    return float(np.mean(scores)) if scores else 0.0
+
+
+def train_risk_rules(X: pd.DataFrame, y: List[int]):
+    """Train a decision tree and return model with feature importances."""
+    model = DecisionTreeClassifier(max_depth=3)
+    model.fit(X, y)
+    feature_importances = dict(zip(X.columns, model.feature_importances_))
+    return model, feature_importances

--- a/example.ipynb
+++ b/example.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Doom Watch Example Notebook\n",
+    "\n",
+    "This notebook demonstrates how to use `doom_watch.py` to fetch simulated data, compute a risk score, and plot the indicator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import doom_watch\n",
+    "\n",
+    "# Fetch the simulated live data\n",
+    "data = doom_watch.get_live_data()\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate the risk score using the fetched data\n",
+    "score = doom_watch.calculate_risk_score(data)\n",
+    "score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the risk indicator for the calculated score\n",
+    "doom_watch.plot_risk_indicator(score)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/llm_scenarios.py
+++ b/llm_scenarios.py
@@ -1,0 +1,17 @@
+"""LLM-based scenario generation utilities."""
+
+import openai
+
+
+def generate_scenario(prompt: str) -> str:
+    """Return LLM-generated scenario text."""
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}],
+            timeout=10,
+        )
+        return response["choices"][0]["message"]["content"].strip()
+    except Exception:
+        return ""
+

--- a/market_watch.py
+++ b/market_watch.py
@@ -1,0 +1,41 @@
+"""Market monitoring utilities for BIST and search trends."""
+
+from typing import List
+
+import logging
+import pandas as pd
+import yfinance as yf
+from pytrends.request import TrendReq
+
+from alerts import send_telegram
+
+
+def check_bist_crash(threshold: float = -0.05) -> bool:
+    """Return True and alert if BIST-100 drops beyond threshold."""
+    try:
+        bist = yf.Ticker("XU100.IS")
+        df = bist.history(period="2d")
+        pct = df["Close"].pct_change().iloc[-1]
+        if pct < threshold:
+            send_telegram("\U0001F6A8 BIST DROPPING 5%!")
+            return True
+    except Exception as exc:
+        logging.warning("bist check failed: %s", exc)
+    return False
+
+
+def check_google_trends(keywords: List[str]) -> bool:
+    """Check if search interest spikes above 80% of 12-month max."""
+    try:
+        pytrends = TrendReq(hl="tr")
+        pytrends.build_payload(keywords, timeframe="today 12-m")
+        data = pytrends.interest_over_time()
+        if data.empty:
+            return False
+        scores = data[keywords].iloc[-1]
+        if (scores / data[keywords].max()).max() > 0.8:
+            return True
+    except Exception as exc:
+        logging.warning("google trends failed: %s", exc)
+    return False
+

--- a/momentum.py
+++ b/momentum.py
@@ -1,0 +1,22 @@
+# Momentum feature calculations for economic data.
+from typing import Dict, List
+
+import numpy as np
+
+
+def calc_momentum_features(data_window: List[Dict[str, float]]) -> Dict[str, float]:
+    """Return simple trend and volatility acceleration features."""
+    if len(data_window) < 2:
+        return {"trend": 0.0, "vol_acceleration": 0.0}
+
+    keys = sorted(data_window[0].keys())
+    arr = np.array([[d.get(k, 0.0) for k in keys] for d in data_window], dtype=float)
+
+    trend = float(np.mean(arr[-1] - arr[0]))
+
+    mid = len(arr) // 2
+    first_std = float(np.std(arr[:mid], ddof=1)) if mid > 1 else 0.0
+    last_std = float(np.std(arr[mid:], ddof=1))
+    vol_acc = last_std - first_std
+
+    return {"trend": trend, "vol_acceleration": vol_acc}

--- a/politika_scenarios.py
+++ b/politika_scenarios.py
@@ -1,0 +1,34 @@
+# Policy scenario definitions for the doom-watch project.
+# These scenarios add extra risk depending on economic conditions.
+from typing import Dict, Tuple, List
+
+
+# Each scenario checks the incoming data and, if conditions are met,
+# returns an additional risk adjustment between 0 and 1.
+SCENARIOS = [
+    {
+        "name": "high_interest_low_confidence",
+        "impact": 0.05,
+        "check": lambda d: d.get("faiz_orani", 0) > 0.5
+        and d.get("guven_endeksi_degisimi", 0) < -0.01,
+    },
+    {
+        "name": "political_uncertainty",
+        "impact": 0.03,
+        "check": lambda d: d.get("politik_belirsizlik_skoru", 0) > 0.8,
+    },
+]
+
+
+def scenario_adjustment(data: Dict[str, float]) -> Tuple[float, List[str]]:
+    """Return extra risk and triggered scenario names."""
+    total_adjustment = 0.0
+    triggered: List[str] = []
+    for scen in SCENARIOS:
+        try:
+            if scen["check"](data):
+                total_adjustment += scen["impact"]
+                triggered.append(scen["name"])
+        except Exception:
+            continue
+    return total_adjustment, triggered

--- a/rule_miner.py
+++ b/rule_miner.py
@@ -1,0 +1,16 @@
+# Rule mining for economic risk scenarios.
+from typing import List
+
+import pandas as pd
+from sklearn.tree import DecisionTreeClassifier, export_text
+
+
+def learn_scenarios(X: pd.DataFrame, y: List[int]) -> List[str]:
+    """Learn decision rules that trigger risk."""
+    if X.empty or not y:
+        return []
+
+    clf = DecisionTreeClassifier(max_depth=3, random_state=42)
+    clf.fit(X, y)
+    rules = export_text(clf, feature_names=list(X.columns))
+    return rules.splitlines()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,119 @@
+# Streamlit arayüzü.
+# doom_watch modülündeki fonksiyonları kullanarak risk göstergesini günceller.
+
+import datetime
+import matplotlib
+matplotlib.use("Agg")  # Arayüzde grafik gösterebilmek için
+import matplotlib.pyplot as plt
+import pandas as pd
+import streamlit as st
+
+import doom_watch as dw
+import random  # Otomotiv verisi için geçici olarak random da kullanılabilir
+from sentiment import get_sentiment_score  # <-- Bu satırı ekledim!
+
+# Uygulama başlığı
+st.title("Türkiye Ekonomisi Kıyamet Saati \U0001F570\ufe0f")
+
+# Oturumda skor geçmişi tutulur
+if "history" not in st.session_state:
+    st.session_state.history = []
+if "otomotiv_data" not in st.session_state:
+    st.session_state.otomotiv_data = random.uniform(-0.15, 0.05)
+
+# Tarih seçici (simülasyon amaçlı)
+selected_date = st.date_input("\U0001F4C5 Tarih Seç", value=datetime.date.today())
+
+st.markdown("---")  # Ayırıcı
+
+# Otomotiv Talep Değişimi için manuel giriş alanı
+st.subheader("Manuel Veri Girişi")
+otomotiv_input = st.number_input(
+    "Otomotiv Talep Değişimi (Örn: -0.05 için -%5)",
+    min_value=-0.5,
+    max_value=0.5,
+    value=st.session_state.otomotiv_data,
+    step=0.01,
+    format="%.2f",
+    help=(
+        "Son 3 aylık otomotiv talebindeki değişimi ifade eder. "
+        "Pozitif değer artış, negatif değer düşüş anlamına gelir. "
+        "(Örn: 0.05 veya -0.10)"
+    ),
+)
+st.session_state.otomotiv_data = otomotiv_input
+
+# Kullanıcının duyduğu negatif haberi girmesi için metin kutusu
+user_news = st.text_area(
+    "Bugün duyduğun herhangi bir negatif gelişmeyi buraya gir (isteğe bağlı)",
+    "",
+)
+
+st.markdown("---")  # Ayırıcı
+
+# Veriyi güncelleyen buton
+if st.button("Veriyi Güncelle ve Risk Skorunu Hesapla \U0001F4B8"):
+    st.write("Veriler çekiliyor ve analiz ediliyor, lütfen bekleyin...")
+
+    # Mevcut veriyi çek (API yerine simüle ve RSS destekli)
+    data = dw.get_live_data()
+
+    # Manuel girilen otomotiv verisini entegre et
+    data["otomotiv_talep_degisimi"] = st.session_state.otomotiv_data
+
+    # Kullanıcının girdiği haber varsa mevcut duygu skoruyla harmanla
+    if user_news.strip():
+        user_sent = get_sentiment_score([user_news])
+        data["public_sentiment"] = (
+            data.get("public_sentiment", 0.0) + user_sent
+        ) / 2
+
+    # Risk skorunu hesapla
+    score, scenarios = dw.calculate_risk_score(data)
+
+    # Güncel risk skorunu ekrana yaz
+    st.subheader(f"Güncel Risk Skoru: **{score:.2f}**")
+
+    if score > 0.75:
+        st.error(
+            "\U0001F6A8 UYARI: Risk Seviyesi Yüksek! Piyasalar alarm veriyor. "
+            "Kıyamet Saati yaklaşıyor!"
+        )
+    elif score > 0.55:
+        st.warning(
+            "\U0001F6A7 DİKKAT: Risk Seviyesi Orta! Gelişmeler yakından takip edilmeli."
+        )
+    else:
+        st.success(
+            "\U0001F7E2 NORMAL: Risk Seviyesi Düşük. Piyasalar sakin seyrediyor."
+        )
+
+    if scenarios:
+        st.info(f"**Tetiklenen Senaryolar:** {', '.join(scenarios)}")
+
+    # Son 7 gün tablosu için skor kaydı
+    st.session_state.history.append({"Tarih": selected_date, "Skor": round(score, 2)})
+    st.session_state.history = st.session_state.history[-7:]
+
+    # Grafiği çiz ve göster
+    st.subheader("Risk Göstergesi Grafiği")
+    dw.plot_risk_indicator(score)
+    fig = plt.gcf()
+    st.pyplot(fig)
+
+    # BIST Crash kontrolü
+    if dw.check_bist_crash():
+        st.warning("\U0001F6A8 BIST'te ani düşüş tespit edildi!")
+else:
+    st.info(
+        "Verileri güncellemek ve risk skorunu görmek için yukarıdaki butona tıklayın."
+    )
+
+st.markdown("---")  # Ayırıcı
+
+# Son 7 günün skor geçmişi
+if st.session_state.history:
+    st.subheader("Son 7 Günün Risk Skorları")
+    df = pd.DataFrame(st.session_state.history)
+    df["Tarih"] = pd.to_datetime(df["Tarih"]).dt.strftime("%Y-%m-%d")
+    st.table(df.set_index("Tarih"))


### PR DESCRIPTION
## Summary
- rewrite `sentiment.py` to pull data from various RSS feeds
- compute sentiment scores with Turkish BERT
- simplify live data logic with random fallback
- add Streamlit interface improvements including manual data input and risk warnings
- update shared `analyze_sentiment` helper to use Turkish BERT
- add manual user news input to adjust public sentiment
- add a Turkish README for running the project locally
- fix wording around triggered scenarios
- add comment indicating added sentiment import

## Testing
- `python -m py_compile doom_watch.py politika_scenarios.py streamlit_app.py anomaly.py momentum.py sentiment.py rule_miner.py alerts.py market_watch.py llm_scenarios.py doom_watch_modules.py`

------
https://chatgpt.com/codex/tasks/task_e_6845dba9bb2c832db326c96087790120